### PR TITLE
Revert "Switch plugin_cerberus to Scold mode"

### DIFF
--- a/src/plugin_cerberus.ml
+++ b/src/plugin_cerberus.ml
@@ -304,9 +304,6 @@ let check ctx muc_context xmpp env jid_from place text =
             report ctx room_env xmpp env jid_from place word text;
           if jid_from.lresource <> "" then
             match ctx.action with
-              | Scold -> env.env_message xmpp (Some Groupchat) jid_from
-                         (Lang.get_msg env.env_lang "plugin_cerberus_cannot_kick_admin" []);
-                         false
               | Kick
               | Ban ->
                   if can_kill room_env jid_from then
@@ -392,7 +389,7 @@ let plugin opts =
       | "kick" -> Kick
       | "ban" -> Ban
       | "scold" -> Scold
-      | _ -> Scold
+      | _ -> Kick
   in
     Muc.add_for_muc_context
       (fun muc_context xmpp ->


### PR DESCRIPTION
This reverts commit 0264852bd28326ee8e3e3cf3e3a51c26d6d837e8.

Some users abuse this commit using offensive nicknames.